### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-standard": "^3.1.0",
     "lodash-cli": "^4.17.5",
     "nyc": "^11.7.1",
-    "stencila-node": "^0.28.9",
+    "stencila-node": "0.28.9",
     "tap-spec": "^4.1.1",
     "tape": "^4.9.0"
   },


### PR DESCRIPTION
# Why?
Currently the library can not be built because of a regression in `stencila-node`.

# What?
This bumps `stencila-node` to a working version.

For this reason I suggest we avoid using `^` in package dependencies.